### PR TITLE
Tweaks to ExternalPropertyProvider

### DIFF
--- a/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
+++ b/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 public class ExternalPropertyProvider implements ConfigProvider {
 
     @VisibleForTesting
-    static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".config.properties");
+    static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".kiwi.external.config.properties");
 
     @Getter
     private Path propertiesPath;
@@ -34,7 +34,7 @@ public class ExternalPropertyProvider implements ConfigProvider {
      * Creates the provider with the default config path
      */
     public ExternalPropertyProvider() {
-        this(DEFAULT_CONFIG_PATH);
+        setPropertiesPath(getDefaultConfigPath());
     }
 
     /**
@@ -93,5 +93,17 @@ public class ExternalPropertyProvider implements ConfigProvider {
     public void usePropertyIfPresent(String propertyKey, Consumer<String> propertyValueConsumer, Runnable orElse) {
         var propertyValue = getProperty(propertyKey);
         propertyValue.ifPresentOrElse(propertyValueConsumer, orElse);
+    }
+
+    /**
+     * Return the default path for the config properties file.
+     * <p>
+     * The easiest way to change the default file path without explicitly passing it into the constructor is to extend
+     * this class and override this method.
+     *
+     * @return The path to the config properties file.
+     */
+    protected Path getDefaultConfigPath() {
+        return DEFAULT_CONFIG_PATH;
     }
 }

--- a/src/main/java/org/kiwiproject/config/ResolvedBy.java
+++ b/src/main/java/org/kiwiproject/config/ResolvedBy.java
@@ -1,0 +1,36 @@
+package org.kiwiproject.config;
+
+/**
+ * Explains how a specific configuration value was resolved.
+ */
+public enum ResolvedBy {
+
+    /**
+     * Resolved by the provider's default mechanism
+     */
+    DEFAULT,
+
+    /**
+     * Resolved from external configuration
+     *
+     * @see ExternalPropertyProvider
+     */
+    EXTERNAL_PROPERTY,
+
+    /**
+     * Resolved from a system property
+     *
+     * @see System#getProperty(String)
+     */
+    SYSTEM_PROPERTY,
+
+    /**
+     * Resolved by an explicit value being supplied, e.g. to a constructor or via a (static) factory method.
+     */
+    EXPLICIT_VALUE,
+
+    /**
+     * Resolution did not occur; no value was resolved
+     */
+    NONE
+}

--- a/src/main/java/org/kiwiproject/config/ServiceIdentityProvider.java
+++ b/src/main/java/org/kiwiproject/config/ServiceIdentityProvider.java
@@ -1,0 +1,61 @@
+package org.kiwiproject.config;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotBlank;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.jar.Jars;
+
+@Getter
+@Slf4j
+public class ServiceIdentityProvider implements ConfigProvider {
+
+    private String name;
+    private ResolvedBy nameResolvedBy;
+
+    private String version;
+    private ResolvedBy versionResolvedBy;
+
+    private String environment;
+    private ResolvedBy environmentResolvedBy;
+
+    public ServiceIdentityProvider() {
+        // TODO: When kiwi 0.10.0 is released, rename this to KiwiJars
+        var path = Jars.getPath(this.getClass());
+        path.ifPresent(val -> resolveIdentity(val, new ExternalPropertyProvider()));
+    }
+
+    public ServiceIdentityProvider(String path) {
+        this(path, new ExternalPropertyProvider());
+    }
+
+    public ServiceIdentityProvider(String path, ExternalPropertyProvider propertyProvider) {
+        resolveIdentity(path, propertyProvider);
+    }
+
+    public ServiceIdentityProvider(String name, String version, String environment) {
+        this.name = requireNotBlank(name);
+        this.nameResolvedBy = ResolvedBy.EXPLICIT_VALUE;
+        this.version = requireNotBlank(version);
+        this.versionResolvedBy = ResolvedBy.EXPLICIT_VALUE;
+        this.environment = requireNotBlank(environment);
+        this.environmentResolvedBy = ResolvedBy.EXPLICIT_VALUE;
+    }
+
+    @Override
+    public boolean canProvide() {
+        return isNotBlank(name) && isNotBlank(version) && isNotBlank(environment);
+    }
+
+    protected void resolveIdentity(String path, ExternalPropertyProvider externalProvider) {
+        initializeResolutionsToNone();
+//        resolveIdentityFromSystemProperties()
+    }
+
+    private void initializeResolutionsToNone() {
+        nameResolvedBy = ResolvedBy.NONE;
+        versionResolvedBy = ResolvedBy.NONE;
+        environmentResolvedBy = ResolvedBy.NONE;
+    }
+}


### PR DESCRIPTION
* Renamed the default config properties path to not be so generic
* Added an overridable getter so that it is easier for systems to change the default config property path