### PR TITLE
Tweak defaults for ExternalPropertyProvider

### DIFF
--- a/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
+++ b/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
@@ -1,8 +1,10 @@
 package org.kiwiproject.config;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.collect.KiwiMaps.isNotNullOrEmpty;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,18 +25,29 @@ import java.util.function.Consumer;
 public class ExternalPropertyProvider implements ConfigProvider {
 
     @VisibleForTesting
-    static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".config.properties");
+    static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".kiwi.external.config.properties");
 
-    @Getter
+    @VisibleForTesting
+    static final String DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY = "kiwi-external-config-path";
+
+    @Getter(AccessLevel.PACKAGE)
     private Path propertiesPath;
 
     private Properties properties;
 
     /**
-     * Creates the provider with the default config path
+     * Creates the provider with the default config path.
+     * <p>
+     * This default will first look to see if there is a system property set with the full path, if not then the path
+     * will be set to the {@link ExternalPropertyProvider#DEFAULT_CONFIG_PATH}.
      */
     public ExternalPropertyProvider() {
-        this(DEFAULT_CONFIG_PATH);
+        var pathFromProps = System.getProperty(DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY);
+        if (isNotBlank(pathFromProps)) {
+            setPropertiesPath(Path.of(pathFromProps));
+        } else {
+            setPropertiesPath(DEFAULT_CONFIG_PATH);
+        }
     }
 
     /**

--- a/src/test/java/org/kiwiproject/config/ExternalPropertyProviderTest.java
+++ b/src/test/java/org/kiwiproject/config/ExternalPropertyProviderTest.java
@@ -27,10 +27,21 @@ class ExternalPropertyProviderTest {
     class Construct {
 
         @Test
-        void shouldCreateDefault() {
+        void shouldCreateDefault_WithoutSystemProperty() {
             var provider = new ExternalPropertyProvider();
             assertThat(provider.canProvide()).isFalse();
             assertThat(provider.getPropertiesPath()).isEqualTo(ExternalPropertyProvider.DEFAULT_CONFIG_PATH);
+        }
+
+        @Test
+        void shouldCreateDefault_WithSystemProperty() {
+            System.setProperty(ExternalPropertyProvider.DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY, "/foo");
+
+            var provider = new ExternalPropertyProvider();
+            assertThat(provider.canProvide()).isFalse();
+            assertThat(provider.getPropertiesPath()).isEqualTo(Path.of("/foo"));
+
+            System.clearProperty(ExternalPropertyProvider.DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY);
         }
 
         @Test
@@ -68,6 +79,7 @@ class ExternalPropertyProviderTest {
         }
 
         @Test
+        @SuppressWarnings("java:S3415")
         void shouldCallOrElse_WhenNotFound() {
             provider.usePropertyIfPresent("unit.test.baz",
                     value -> fail("Test should have called the else not the consumer"),


### PR DESCRIPTION
* Rename the default config properties path to not be so generic
* Add system property that can be set as the default config property path