### PR TITLE
Use try-with-resources to ensure reader is closed

### DIFF
--- a/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
+++ b/src/main/java/org/kiwiproject/config/ExternalPropertyProvider.java
@@ -77,10 +77,11 @@ public class ExternalPropertyProvider implements ConfigProvider {
         properties = new Properties();
 
         if (Files.isReadable(propertiesPath)) {
-            try {
+            try (var reader = Files.newBufferedReader(propertiesPath)) {
                 LOG.debug("Looking up configuration values from file {}", propertiesPath);
-                properties.load(Files.newBufferedReader(propertiesPath));
+                properties.load(reader);
             } catch (IOException e) {
+                // TODO Should this fail-fast right here??? Same question if file not readable.
                 LOG.error("Unable to load properties from file: {}", propertiesPath, e);
             }
         }


### PR DESCRIPTION
* Update ExternalPropertyProvider#updateProperties to use
  try-with-resources to ensure the BufferedReader is closed once the
  properties have been loaded
* Add a TODO regarding whether we should fail fast if there is a
  problem reading the external properties file