### PR TITLE
Use version ranges for kiwi and kiwi-test in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,11 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.1.0</kiwi.version>
+        <kiwi.version>[2.1.0,3.0.0)</kiwi.version>
         <kiwi-bom.version>0.14.0</kiwi-bom.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.1.0</kiwi-test.version>
+        <kiwi-test.version>[2.1.0,3.0.0)</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-config-providers</sonar.projectKey>


### PR DESCRIPTION
* Allow 2.1.0 (inclusive) to 3.0.0 (exclusive)

Closes #155