### PR TITLE
CodeQL: Fix "Missing catch of NumberFormatException"

### DIFF
--- a/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.base.KiwiPrimitives;
 import org.kiwiproject.config.provider.util.PropertyResolutionSettings;
 import org.kiwiproject.config.provider.util.SinglePropertyResolver;
 import org.kiwiproject.json.JsonHelper;
@@ -217,11 +218,11 @@ public class DropwizardDataSourceConfigProvider implements ConfigProvider {
         dataSourceFactory.setPassword(resolveProperty(PASSWORD_FIELD, passwordResolver, externalConfigProvider,
                 kiwiEnvironment, originalFactory.getPassword(), this::setPasswordResolvedBy));
         dataSourceFactory.setMaxSize(resolveProperty(MAX_SIZE_FIELD, maxSizeResolver, externalConfigProvider,
-                kiwiEnvironment, originalFactory.getMaxSize(), this::setMaxSizeResolvedBy, Integer::parseInt));
+                kiwiEnvironment, originalFactory.getMaxSize(), this::setMaxSizeResolvedBy, KiwiPrimitives::tryParseIntOrThrow));
         dataSourceFactory.setMinSize(resolveProperty(MIN_SIZE_FIELD, minSizeResolver, externalConfigProvider,
-                kiwiEnvironment, originalFactory.getMinSize(), this::setMinSizeResolvedBy, Integer::parseInt));
+                kiwiEnvironment, originalFactory.getMinSize(), this::setMinSizeResolvedBy, KiwiPrimitives::tryParseIntOrThrow));
         dataSourceFactory.setInitialSize(resolveProperty(INITIAL_SIZE_FIELD, initialSizeResolver, externalConfigProvider,
-                kiwiEnvironment, originalFactory.getInitialSize(), this::setInitialSizeResolvedBy, Integer::parseInt));
+                kiwiEnvironment, originalFactory.getInitialSize(), this::setInitialSizeResolvedBy, KiwiPrimitives::tryParseIntOrThrow));
 
         var json = new JsonHelper();
 

--- a/src/main/java/org/kiwiproject/config/provider/ElkLoggerConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ElkLoggerConfigProvider.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.base.KiwiPrimitives;
 import org.kiwiproject.config.provider.util.PropertyResolutionSettings;
 import org.kiwiproject.config.provider.util.SinglePropertyResolver;
 import org.kiwiproject.json.JsonHelper;
@@ -95,7 +96,7 @@ public class ElkLoggerConfigProvider implements ConfigProvider {
                 .systemProperty(DEFAULT_PORT_SYSTEM_PROPERTY)
                 .environmentVariable(DEFAULT_PORT_ENV_VARIABLE)
                 .externalKey(DEFAULT_PORT_EXTERNAL_PROPERTY_KEY)
-                .convertFromString(Integer::parseInt)
+                .convertFromString(KiwiPrimitives::tryParseIntOrThrow)
                 .build());
 
         var portValue = portResolution.getValue();

--- a/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.base.KiwiPrimitives;
 import org.kiwiproject.config.provider.util.PropertyResolutionSettings;
 import org.kiwiproject.config.provider.util.SinglePropertyResolver;
 
@@ -93,7 +94,7 @@ public class ElucidationConfigProvider implements ConfigProvider {
                 .systemProperty(DEFAULT_PORT_SYSTEM_PROPERTY)
                 .environmentVariable(DEFAULT_PORT_ENV_VARIABLE)
                 .externalKey(DEFAULT_PORT_EXTERNAL_PROPERTY_KEY)
-                .convertFromString(Integer::parseInt)
+                .convertFromString(KiwiPrimitives::tryParseIntOrThrow)
                 .build());
 
         var portValue = portResolution.getValue();

--- a/src/test/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProviderTest.java
+++ b/src/test/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProviderTest.java
@@ -217,9 +217,8 @@ class DropwizardDataSourceConfigProviderTest {
                 assertFactoryIsCorrect(provider.getDataSourceFactory(), provider, ResolvedBy.SUPPLIER);
             }
 
-            // TODO: @chrisrohr is this test named incorrectly? We assert that canProvide() returns false but the test name includes "CanProvide"
             @Test
-            void shouldBuildUsingDefaultSupplierAndCanProvide() {
+            void shouldBuildUsingDefaultSupplier() {
                 var provider = DropwizardDataSourceConfigProvider.builder().build();
                 assertThat(provider.canProvide()).isFalse();
 


### PR DESCRIPTION
* Replace Integer#parseInt with KiwiPrimitives#tryParseIntOrThrow
* No, this doesn't actually "fix" anything; instead it throws an arguably more relevant exception (IllegalStateException) that wraps the original NumberFormatException. This makes it more clear that the state was not what we expected.

Other:
* Remove TODO from DropwizardDataSourceConfigProviderTest and rename the test by removing "AndCanProvide" at the end of its name, since the default supplier can NOT provide and the test makes this assertion

Closes #193
Closes #194
Closes #195
Closes #196
Closes #197