### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-config-providers</artifactId>
-    <version>1.1.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -30,11 +30,11 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-config-providers</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
@@ -114,7 +114,7 @@ public class ElucidationConfigProvider implements ConfigProvider {
 
         var enabledValue = enabledResolution.getValue();
 
-        this.enabled = !isNull(enabledValue) && enabledValue;
+        this.enabled = Boolean.TRUE.equals(enabledValue);
         this.enabledResolvedBy = enabledResolution.getResolvedBy();
     }
 

--- a/src/main/java/org/kiwiproject/config/provider/ExternalConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ExternalConfigProvider.java
@@ -154,8 +154,8 @@ public class ExternalConfigProvider implements ConfigProvider {
     }
 
     /**
-     * Will check if a given {@link ExternalConfigProvider} is null and return a new one if so. Otherwise return the one
-     * passed in.
+     * Will check if the given {@link ExternalConfigProvider} is null and return a new one if so. Otherwise, return the
+     * one passed in.
      *
      * @param provided an {@link ExternalConfigProvider} to test for null
      * @return A new {@link ExternalConfigProvider} if the given {@code provided} is null or {@code provided}


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Bump versions of kiwi libraries
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9
* Misc grammar fixes in ExternalConfigProvider
* Simplify "enabled" logic in ElucidationConfigProvider by just using Boolean.TRUE.equals(...)