### PR TITLE
Make external constants in provider classes public

### DIFF
--- a/src/main/java/org/kiwiproject/config/provider/ActiveMQConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ActiveMQConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -24,14 +23,11 @@ import java.util.Map;
  */
 public class ActiveMQConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_AMQ_SERVERS_SYSTEM_PROPERTY = "kiwi.amq.connection";
+    public static final String DEFAULT_AMQ_SERVERS_SYSTEM_PROPERTY = "kiwi.amq.connection";
 
-    @VisibleForTesting
-    static final String DEFAULT_AMQ_SERVERS_ENV_VARIABLE = "KIWI_AMQ_CONNECTION";
+    public static final String DEFAULT_AMQ_SERVERS_ENV_VARIABLE = "KIWI_AMQ_CONNECTION";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "amq.connection";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "amq.connection";
 
     @Getter
     private final String activeMQServers;

--- a/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
@@ -4,7 +4,6 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.db.DataSourceFactory;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,77 +42,53 @@ public class DropwizardDataSourceConfigProvider implements ConfigProvider {
     private static final String INITIAL_SIZE_FIELD = "initialSize";
     private static final String ORM_PROPERTIES_FIELD = "ormProperties";
 
-    @VisibleForTesting
-    static final String DEFAULT_DRIVER_CLASS_SYSTEM_PROPERTY = "kiwi.datasource.driverClass";
+    public static final String DEFAULT_DRIVER_CLASS_SYSTEM_PROPERTY = "kiwi.datasource.driverClass";
 
-    @VisibleForTesting
-    static final String DEFAULT_DRIVER_CLASS_ENV_VARIABLE = "KIWI_DATASOURCE_DRIVER_CLASS";
+    public static final String DEFAULT_DRIVER_CLASS_ENV_VARIABLE = "KIWI_DATASOURCE_DRIVER_CLASS";
 
-    @VisibleForTesting
-    static final String DEFAULT_DRIVER_CLASS_EXTERNAL_PROPERTY_KEY = "datasource.driverClass";
+    public static final String DEFAULT_DRIVER_CLASS_EXTERNAL_PROPERTY_KEY = "datasource.driverClass";
 
-    @VisibleForTesting
-    static final String DEFAULT_URL_SYSTEM_PROPERTY = "kiwi.datasource.url";
+    public static final String DEFAULT_URL_SYSTEM_PROPERTY = "kiwi.datasource.url";
 
-    @VisibleForTesting
-    static final String DEFAULT_URL_ENV_VARIABLE = "KIWI_DATASOURCE_URL";
+    public static final String DEFAULT_URL_ENV_VARIABLE = "KIWI_DATASOURCE_URL";
 
-    @VisibleForTesting
-    static final String DEFAULT_URL_EXTERNAL_PROPERTY_KEY = "datasource.url";
+    public static final String DEFAULT_URL_EXTERNAL_PROPERTY_KEY = "datasource.url";
 
-    @VisibleForTesting
-    static final String DEFAULT_USER_SYSTEM_PROPERTY = "kiwi.datasource.user";
+    public static final String DEFAULT_USER_SYSTEM_PROPERTY = "kiwi.datasource.user";
 
-    @VisibleForTesting
-    static final String DEFAULT_USER_ENV_VARIABLE = "KIWI_DATASOURCE_USER";
+    public static final String DEFAULT_USER_ENV_VARIABLE = "KIWI_DATASOURCE_USER";
 
-    @VisibleForTesting
-    static final String DEFAULT_USER_EXTERNAL_PROPERTY_KEY = "datasource.user";
+    public static final String DEFAULT_USER_EXTERNAL_PROPERTY_KEY = "datasource.user";
 
-    @VisibleForTesting
-    static final String DEFAULT_PASSWORD_SYSTEM_PROPERTY = "kiwi.datasource.password";
+    public static final String DEFAULT_PASSWORD_SYSTEM_PROPERTY = "kiwi.datasource.password";
 
-    @VisibleForTesting
-    static final String DEFAULT_PASSWORD_ENV_VARIABLE = "KIWI_DATASOURCE_PASSWORD";
+    public static final String DEFAULT_PASSWORD_ENV_VARIABLE = "KIWI_DATASOURCE_PASSWORD";
 
-    @VisibleForTesting
-    static final String DEFAULT_PASSWORD_EXTERNAL_PROPERTY_KEY = "datasource.password";
+    public static final String DEFAULT_PASSWORD_EXTERNAL_PROPERTY_KEY = "datasource.password";
 
-    @VisibleForTesting
-    static final String DEFAULT_MAX_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.maxSize";
+    public static final String DEFAULT_MAX_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.maxSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_MAX_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_MAX_SIZE";
+    public static final String DEFAULT_MAX_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_MAX_SIZE";
 
-    @VisibleForTesting
-    static final String DEFAULT_MAX_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.maxSize";
+    public static final String DEFAULT_MAX_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.maxSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_MIN_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.minSize";
+    public static final String DEFAULT_MIN_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.minSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_MIN_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_MIN_SIZE";
+    public static final String DEFAULT_MIN_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_MIN_SIZE";
 
-    @VisibleForTesting
-    static final String DEFAULT_MIN_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.minSize";
+    public static final String DEFAULT_MIN_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.minSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_INITIAL_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.initialSize";
+    public static final String DEFAULT_INITIAL_SIZE_SYSTEM_PROPERTY = "kiwi.datasource.initialSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_INITIAL_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_INITIAL_SIZE";
+    public static final String DEFAULT_INITIAL_SIZE_ENV_VARIABLE = "KIWI_DATASOURCE_INITIAL_SIZE";
 
-    @VisibleForTesting
-    static final String DEFAULT_INITIAL_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.initialSize";
+    public static final String DEFAULT_INITIAL_SIZE_EXTERNAL_PROPERTY_KEY = "datasource.initialSize";
 
-    @VisibleForTesting
-    static final String DEFAULT_ORM_PROPERTIES_SYSTEM_PROPERTY = "kiwi.datasource.ormProperties";
+    public static final String DEFAULT_ORM_PROPERTIES_SYSTEM_PROPERTY = "kiwi.datasource.ormProperties";
 
-    @VisibleForTesting
-    static final String DEFAULT_ORM_PROPERTIES_ENV_VARIABLE = "KIWI_DATASOURCE_ORM_PROPERTIES";
+    public static final String DEFAULT_ORM_PROPERTIES_ENV_VARIABLE = "KIWI_DATASOURCE_ORM_PROPERTIES";
 
-    @VisibleForTesting
-    static final String DEFAULT_ORM_PROPERTIES_EXTERNAL_PROPERTY_KEY = "datasource.ormProperties";
+    public static final String DEFAULT_ORM_PROPERTIES_EXTERNAL_PROPERTY_KEY = "datasource.ormProperties";
 
     private static final Map<String, String> DRIVER_CLASS_DEFAULTS = Map.of(
             SYSTEM_PROPERTY, DEFAULT_DRIVER_CLASS_SYSTEM_PROPERTY,

--- a/src/main/java/org/kiwiproject/config/provider/ElkLoggerConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ElkLoggerConfigProvider.java
@@ -4,7 +4,6 @@ import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -28,32 +27,23 @@ import java.util.Map;
  */
 public class ElkLoggerConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_SYSTEM_PROPERTY = "kiwi.elk.host";
+    public static final String DEFAULT_HOST_SYSTEM_PROPERTY = "kiwi.elk.host";
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_ENV_VARIABLE = "KIWI_ELK_HOST";
+    public static final String DEFAULT_HOST_ENV_VARIABLE = "KIWI_ELK_HOST";
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_EXTERNAL_PROPERTY_KEY = "elk.host";
+    public static final String DEFAULT_HOST_EXTERNAL_PROPERTY_KEY = "elk.host";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_SYSTEM_PROPERTY = "kiwi.elk.port";
+    public static final String DEFAULT_PORT_SYSTEM_PROPERTY = "kiwi.elk.port";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_ENV_VARIABLE = "KIWI_ELK_PORT";
+    public static final String DEFAULT_PORT_ENV_VARIABLE = "KIWI_ELK_PORT";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_EXTERNAL_PROPERTY_KEY = "elk.port";
+    public static final String DEFAULT_PORT_EXTERNAL_PROPERTY_KEY = "elk.port";
 
-    @VisibleForTesting
-    static final String DEFAULT_CUSTOM_FIELDS_SYSTEM_PROPERTY = "kiwi.elk.customFields";
+    public static final String DEFAULT_CUSTOM_FIELDS_SYSTEM_PROPERTY = "kiwi.elk.customFields";
 
-    @VisibleForTesting
-    static final String DEFAULT_CUSTOM_FIELDS_ENV_VARIABLE = "KIWI_ELK_CUSTOM_FIELDS";
+    public static final String DEFAULT_CUSTOM_FIELDS_ENV_VARIABLE = "KIWI_ELK_CUSTOM_FIELDS";
 
-    @VisibleForTesting
-    static final String DEFAULT_CUSTOM_FIELDS_EXTERNAL_PROPERTY_KEY = "elk.customFields";
+    public static final String DEFAULT_CUSTOM_FIELDS_EXTERNAL_PROPERTY_KEY = "elk.customFields";
 
     @Getter
     private final String host;

--- a/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ElucidationConfigProvider.java
@@ -3,7 +3,6 @@ package org.kiwiproject.config.provider;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -26,32 +25,23 @@ import java.util.Map;
  */
 public class ElucidationConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_SYSTEM_PROPERTY = "kiwi.elucidation.host";
+    public static final String DEFAULT_HOST_SYSTEM_PROPERTY = "kiwi.elucidation.host";
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_ENV_VARIABLE = "KIWI_ELUCIDATION_HOST";
+    public static final String DEFAULT_HOST_ENV_VARIABLE = "KIWI_ELUCIDATION_HOST";
 
-    @VisibleForTesting
-    static final String DEFAULT_HOST_EXTERNAL_PROPERTY_KEY = "elucidation.host";
+    public static final String DEFAULT_HOST_EXTERNAL_PROPERTY_KEY = "elucidation.host";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_SYSTEM_PROPERTY = "kiwi.elucidation.port";
+    public static final String DEFAULT_PORT_SYSTEM_PROPERTY = "kiwi.elucidation.port";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_ENV_VARIABLE = "KIWI_ELUCIDATION_PORT";
+    public static final String DEFAULT_PORT_ENV_VARIABLE = "KIWI_ELUCIDATION_PORT";
 
-    @VisibleForTesting
-    static final String DEFAULT_PORT_EXTERNAL_PROPERTY_KEY = "elucidation.port";
+    public static final String DEFAULT_PORT_EXTERNAL_PROPERTY_KEY = "elucidation.port";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENABLED_SYSTEM_PROPERTY = "kiwi.elucidation.enabled";
+    public static final String DEFAULT_ENABLED_SYSTEM_PROPERTY = "kiwi.elucidation.enabled";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENABLED_ENV_VARIABLE = "KIWI_ELUCIDATION_ENABLED";
+    public static final String DEFAULT_ENABLED_ENV_VARIABLE = "KIWI_ELUCIDATION_ENABLED";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENABLED_EXTERNAL_PROPERTY_KEY = "elucidation.enabled";
+    public static final String DEFAULT_ENABLED_EXTERNAL_PROPERTY_KEY = "elucidation.enabled";
 
     @Getter
     private final String host;

--- a/src/main/java/org/kiwiproject/config/provider/ExternalConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ExternalConfigProvider.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.collect.KiwiMaps.isNotNullOrEmpty;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,14 +40,11 @@ import java.util.function.Supplier;
 @Slf4j
 public class ExternalConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".kiwi.external.config.properties");
+    public static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".kiwi.external.config.properties");
 
-    @VisibleForTesting
-    static final String DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY = "kiwi.external.config.path";
+    public static final String DEFAULT_CONFIG_PATH_SYSTEM_PROPERTY = "kiwi.external.config.path";
 
-    @VisibleForTesting
-    static final String DEFAULT_CONFIG_PATH_ENV_VARIABLE = "KIWI_EXTERNAL_CONFIG_PATH";
+    public static final String DEFAULT_CONFIG_PATH_ENV_VARIABLE = "KIWI_EXTERNAL_CONFIG_PATH";
 
     @Getter(AccessLevel.PACKAGE)
     private Path propertiesPath;

--- a/src/main/java/org/kiwiproject/config/provider/HibernateConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/HibernateConfigProvider.java
@@ -3,7 +3,6 @@ package org.kiwiproject.config.provider;
 import static org.kiwiproject.collect.KiwiMaps.isNotNullOrEmpty;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -29,17 +28,13 @@ public class HibernateConfigProvider implements ConfigProvider {
 
     private static final JsonHelper JSON_HELPER = JsonHelper.newDropwizardJsonHelper();
 
-    @VisibleForTesting
-    static final String DEFAULT_HIBERNATE_SYSTEM_PROPERTY = "kiwi.hibernate.properties";
+    public static final String DEFAULT_HIBERNATE_SYSTEM_PROPERTY = "kiwi.hibernate.properties";
 
-    @VisibleForTesting
-    static final String DEFAULT_HIBERNATE_ENV_VARIABLE = "KIWI_HIBERNATE_PROPERTIES";
+    public static final String DEFAULT_HIBERNATE_ENV_VARIABLE = "KIWI_HIBERNATE_PROPERTIES";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "hibernate.properties";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "hibernate.properties";
 
-    @VisibleForTesting
-    static final Map<String, Object> DEFAULT_HIBERNATE_PROPERTIES = Map.of(
+    public static final Map<String, Object> DEFAULT_HIBERNATE_PROPERTIES = Map.of(
             "hibernate.show_sql", false,
             "hibernate.format_sql", true,
             "hibernate.use_sql_comments", true

--- a/src/main/java/org/kiwiproject/config/provider/MongoConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/MongoConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -24,14 +23,11 @@ import java.util.Map;
  */
 public class MongoConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_MONGO_SYSTEM_PROPERTY = "kiwi.mongo.connection";
+    public static final String DEFAULT_MONGO_SYSTEM_PROPERTY = "kiwi.mongo.connection";
 
-    @VisibleForTesting
-    static final String DEFAULT_MONGO_ENV_VARIABLE = "KIWI_MONGO_CONNECTION";
+    public static final String DEFAULT_MONGO_ENV_VARIABLE = "KIWI_MONGO_CONNECTION";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "mongo.connection";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "mongo.connection";
 
     @Getter
     private final String url;

--- a/src/main/java/org/kiwiproject/config/provider/NetworkIdentityConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/NetworkIdentityConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -26,14 +25,11 @@ import java.util.Map;
  */
 public class NetworkIdentityConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_NETWORK_SYSTEM_PROPERTY = "kiwi.network";
+    public static final String DEFAULT_NETWORK_SYSTEM_PROPERTY = "kiwi.network";
 
-    @VisibleForTesting
-    static final String DEFAULT_NETWORK_ENV_VARIABLE = "KIWI_NETWORK";
+    public static final String DEFAULT_NETWORK_ENV_VARIABLE = "KIWI_NETWORK";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "network";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "network";
 
     @Getter
     private final String network;

--- a/src/main/java/org/kiwiproject/config/provider/ServiceIdentityConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ServiceIdentityConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -25,32 +24,23 @@ import java.util.Map;
  */
 public class ServiceIdentityConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_NAME_SYSTEM_PROPERTY = "kiwi.service.name";
+    public static final String DEFAULT_NAME_SYSTEM_PROPERTY = "kiwi.service.name";
 
-    @VisibleForTesting
-    static final String DEFAULT_NAME_ENV_VARIABLE = "KIWI_SERVICE_NAME";
+    public static final String DEFAULT_NAME_ENV_VARIABLE = "KIWI_SERVICE_NAME";
 
-    @VisibleForTesting
-    static final String DEFAULT_NAME_EXTERNAL_PROPERTY_KEY = "service.name";
+    public static final String DEFAULT_NAME_EXTERNAL_PROPERTY_KEY = "service.name";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERSION_SYSTEM_PROPERTY = "kiwi.service.version";
+    public static final String DEFAULT_VERSION_SYSTEM_PROPERTY = "kiwi.service.version";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERSION_ENV_VARIABLE = "KIWI_SERVICE_VERSION";
+    public static final String DEFAULT_VERSION_ENV_VARIABLE = "KIWI_SERVICE_VERSION";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERSION_EXTERNAL_PROPERTY_KEY = "service.version";
+    public static final String DEFAULT_VERSION_EXTERNAL_PROPERTY_KEY = "service.version";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENVIRONMENT_SYSTEM_PROPERTY = "kiwi.service.env";
+    public static final String DEFAULT_ENVIRONMENT_SYSTEM_PROPERTY = "kiwi.service.env";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENVIRONMENT_ENV_VARIABLE = "KIWI_SERVICE_ENV";
+    public static final String DEFAULT_ENVIRONMENT_ENV_VARIABLE = "KIWI_SERVICE_ENV";
 
-    @VisibleForTesting
-    static final String DEFAULT_ENVIRONMENT_EXTERNAL_PROPERTY_KEY = "service.env";
+    public static final String DEFAULT_ENVIRONMENT_EXTERNAL_PROPERTY_KEY = "service.env";
 
     @Getter
     private final String name;

--- a/src/main/java/org/kiwiproject/config/provider/SharedStorageConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/SharedStorageConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -24,14 +23,11 @@ import java.util.Map;
  */
 public class SharedStorageConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_SHARED_STORAGE_PATH_SYSTEM_PROPERTY = "kiwi.shared.storage.path";
+    public static final String DEFAULT_SHARED_STORAGE_PATH_SYSTEM_PROPERTY = "kiwi.shared.storage.path";
 
-    @VisibleForTesting
-    static final String DEFAULT_SHARED_STORAGE_PATH_ENV_VARIABLE = "KIWI_SHARED_STORAGE_PATH";
+    public static final String DEFAULT_SHARED_STORAGE_PATH_ENV_VARIABLE = "KIWI_SHARED_STORAGE_PATH";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "shared.storage.path";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "shared.storage.path";
 
     @Getter
     private final String sharedStoragePath;

--- a/src/main/java/org/kiwiproject/config/provider/TlsConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/TlsConfigProvider.java
@@ -4,7 +4,6 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.collect.KiwiMaps.newUnmodifiableHashMap;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,104 +45,71 @@ public class TlsConfigProvider implements ConfigProvider {
     private static final String SUPPORTED_PROTOCOLS_FIELD = "supportedProtocols";
     private static final String SUPPORTED_CIPHERS_FIELD = "supportedCiphers";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PATH_SYSTEM_PROPERTY = "kiwi.tls.keyStorePath";
+    public static final String DEFAULT_KEYSTORE_PATH_SYSTEM_PROPERTY = "kiwi.tls.keyStorePath";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PATH_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_PATH";
+    public static final String DEFAULT_KEYSTORE_PATH_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_PATH";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PATH_EXTERNAL_PROPERTY_KEY = "tls.keyStorePath";
+    public static final String DEFAULT_KEYSTORE_PATH_EXTERNAL_PROPERTY_KEY = "tls.keyStorePath";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PASSWORD_SYSTEM_PROPERTY = "kiwi.tls.keyStorePassword";
+    public static final String DEFAULT_KEYSTORE_PASSWORD_SYSTEM_PROPERTY = "kiwi.tls.keyStorePassword";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PASSWORD_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_PASSWORD";
+    public static final String DEFAULT_KEYSTORE_PASSWORD_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_PASSWORD";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_PASSWORD_EXTERNAL_PROPERTY_KEY = "tls.keyStorePassword";
+    public static final String DEFAULT_KEYSTORE_PASSWORD_EXTERNAL_PROPERTY_KEY = "tls.keyStorePassword";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_TYPE_SYSTEM_PROPERTY = "kiwi.tls.keyStoreType";
+    public static final String DEFAULT_KEYSTORE_TYPE_SYSTEM_PROPERTY = "kiwi.tls.keyStoreType";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_TYPE_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_TYPE";
+    public static final String DEFAULT_KEYSTORE_TYPE_ENV_VARIABLE = "KIWI_TLS_KEYSTORE_TYPE";
 
-    @VisibleForTesting
-    static final String DEFAULT_KEYSTORE_TYPE_EXTERNAL_PROPERTY_KEY = "tls.keyStoreType";
+    public static final String DEFAULT_KEYSTORE_TYPE_EXTERNAL_PROPERTY_KEY = "tls.keyStoreType";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PATH_SYSTEM_PROPERTY = "kiwi.tls.trustStorePath";
+    public static final String DEFAULT_TRUSTSTORE_PATH_SYSTEM_PROPERTY = "kiwi.tls.trustStorePath";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PATH_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_PATH";
+    public static final String DEFAULT_TRUSTSTORE_PATH_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_PATH";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PATH_EXTERNAL_PROPERTY_KEY = "tls.trustStorePath";
+    public static final String DEFAULT_TRUSTSTORE_PATH_EXTERNAL_PROPERTY_KEY = "tls.trustStorePath";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY = "kiwi.tls.trustStorePassword";
+    public static final String DEFAULT_TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY = "kiwi.tls.trustStorePassword";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PASSWORD_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_PASSWORD";
+    public static final String DEFAULT_TRUSTSTORE_PASSWORD_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_PASSWORD";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_PASSWORD_EXTERNAL_PROPERTY_KEY = "tls.trustStorePassword";
+    public static final String DEFAULT_TRUSTSTORE_PASSWORD_EXTERNAL_PROPERTY_KEY = "tls.trustStorePassword";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_TYPE_SYSTEM_PROPERTY = "kiwi.tls.trustStoreType";
+    public static final String DEFAULT_TRUSTSTORE_TYPE_SYSTEM_PROPERTY = "kiwi.tls.trustStoreType";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_TYPE_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_TYPE";
+    public static final String DEFAULT_TRUSTSTORE_TYPE_ENV_VARIABLE = "KIWI_TLS_TRUSTSTORE_TYPE";
 
-    @VisibleForTesting
-    static final String DEFAULT_TRUSTSTORE_TYPE_EXTERNAL_PROPERTY_KEY = "tls.trustStoreType";
+    public static final String DEFAULT_TRUSTSTORE_TYPE_EXTERNAL_PROPERTY_KEY = "tls.trustStoreType";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERIFY_HOSTNAME_SYSTEM_PROPERTY = "kiwi.tls.verifyHostname";
+    public static final String DEFAULT_VERIFY_HOSTNAME_SYSTEM_PROPERTY = "kiwi.tls.verifyHostname";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERIFY_HOSTNAME_ENV_VARIABLE = "KIWI_TLS_VERIFY_HOSTNAME";
+    public static final String DEFAULT_VERIFY_HOSTNAME_ENV_VARIABLE = "KIWI_TLS_VERIFY_HOSTNAME";
 
-    @VisibleForTesting
-    static final String DEFAULT_VERIFY_HOSTNAME_EXTERNAL_PROPERTY_KEY = "tls.verifyHostname";
+    public static final String DEFAULT_VERIFY_HOSTNAME_EXTERNAL_PROPERTY_KEY = "tls.verifyHostname";
 
-    @VisibleForTesting
-    static final String DEFAULT_DISABLE_SNI_HOST_CHECK_SYSTEM_PROPERTY = "kiwi.tls.disableSniHostCheck";
+    public static final String DEFAULT_DISABLE_SNI_HOST_CHECK_SYSTEM_PROPERTY = "kiwi.tls.disableSniHostCheck";
 
-    @VisibleForTesting
-    static final String DEFAULT_DISABLE_SNI_HOST_CHECK_ENV_VARIABLE = "KIWI_TLS_DISABLE_SNI_HOST_CHECK";
+    public static final String DEFAULT_DISABLE_SNI_HOST_CHECK_ENV_VARIABLE = "KIWI_TLS_DISABLE_SNI_HOST_CHECK";
 
-    @VisibleForTesting
-    static final String DEFAULT_DISABLE_SNI_HOST_CHECK_EXTERNAL_PROPERTY_KEY = "tls.disableSniHostCheck";
+    public static final String DEFAULT_DISABLE_SNI_HOST_CHECK_EXTERNAL_PROPERTY_KEY = "tls.disableSniHostCheck";
 
-    @VisibleForTesting
-    static final String DEFAULT_PROTOCOL_SYSTEM_PROPERTY = "kiwi.tls.protocol";
+    public static final String DEFAULT_PROTOCOL_SYSTEM_PROPERTY = "kiwi.tls.protocol";
 
-    @VisibleForTesting
-    static final String DEFAULT_PROTOCOL_ENV_VARIABLE = "KIWI_TLS_PROTOCOL";
+    public static final String DEFAULT_PROTOCOL_ENV_VARIABLE = "KIWI_TLS_PROTOCOL";
 
-    @VisibleForTesting
-    static final String DEFAULT_PROTOCOL_EXTERNAL_PROPERTY_KEY = "tls.protocol";
+    public static final String DEFAULT_PROTOCOL_EXTERNAL_PROPERTY_KEY = "tls.protocol";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_PROTOCOLS_SYSTEM_PROPERTY = "kiwi.tls.supportedProtocols";
+    public static final String DEFAULT_SUPPORTED_PROTOCOLS_SYSTEM_PROPERTY = "kiwi.tls.supportedProtocols";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_PROTOCOLS_ENV_VARIABLE = "KIWI_TLS_SUPPORTED_PROTOCOLS";
+    public static final String DEFAULT_SUPPORTED_PROTOCOLS_ENV_VARIABLE = "KIWI_TLS_SUPPORTED_PROTOCOLS";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_PROTOCOLS_EXTERNAL_PROPERTY_KEY = "tls.supportedProtocols";
+    public static final String DEFAULT_SUPPORTED_PROTOCOLS_EXTERNAL_PROPERTY_KEY = "tls.supportedProtocols";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_CIPHERS_SYSTEM_PROPERTY = "kiwi.tls.supportedCiphers";
+    public static final String DEFAULT_SUPPORTED_CIPHERS_SYSTEM_PROPERTY = "kiwi.tls.supportedCiphers";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_CIPHERS_ENV_VARIABLE = "KIWI_TLS_SUPPORTED_CIPHERS";
+    public static final String DEFAULT_SUPPORTED_CIPHERS_ENV_VARIABLE = "KIWI_TLS_SUPPORTED_CIPHERS";
 
-    @VisibleForTesting
-    static final String DEFAULT_SUPPORTED_CIPHERS_EXTERNAL_PROPERTY_KEY = "tls.supportedCiphers";
+    public static final String DEFAULT_SUPPORTED_CIPHERS_EXTERNAL_PROPERTY_KEY = "tls.supportedCiphers";
 
     private static final Map<String, String> KEYSTORE_PATH_DEFAULTS = Map.of(
             SYSTEM_PROPERTY, DEFAULT_KEYSTORE_PATH_SYSTEM_PROPERTY,

--- a/src/main/java/org/kiwiproject/config/provider/ZooKeeperConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/ZooKeeperConfigProvider.java
@@ -2,7 +2,6 @@ package org.kiwiproject.config.provider;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.Builder;
 import lombok.Getter;
 import org.kiwiproject.base.KiwiEnvironment;
@@ -24,14 +23,11 @@ import java.util.Map;
  */
 public class ZooKeeperConfigProvider implements ConfigProvider {
 
-    @VisibleForTesting
-    static final String DEFAULT_CONNECT_STRING_SYSTEM_PROPERTY = "kiwi.zookeeper.connection";
+    public static final String DEFAULT_CONNECT_STRING_SYSTEM_PROPERTY = "kiwi.zookeeper.connection";
 
-    @VisibleForTesting
-    static final String DEFAULT_CONNECT_STRING_ENV_VARIABLE = "KIWI_ZOOKEEPER_CONNECTION";
+    public static final String DEFAULT_CONNECT_STRING_ENV_VARIABLE = "KIWI_ZOOKEEPER_CONNECTION";
 
-    @VisibleForTesting
-    static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "zookeeper.connection";
+    public static final String DEFAULT_EXTERNAL_PROPERTY_KEY = "zookeeper.connection";
 
     @Getter
     private final String connectString;


### PR DESCRIPTION
The DEFAULT_* constants in all XxxProvider classes represent the external contract of the library: the system property names, environment variable names, and external config file keys that users must configure in shell scripts, config files, and utilities. Making them public lets callers reference the canonical constant rather than duplicating the string literal.

The @VisibleForTesting annotations are removed since they are no longer needed once the constants are public. Internal implementation constants (*_FIELD, *_DEFAULTS maps, DEFAULTS_FOR_PROPERTIES, JSON_HELPER) remain private as they carry no external meaning.

Closes #377