### PR TITLE
Add Javadoc listing lookup keys to DropwizardDataSourceConfigProvider and TlsConfigProvider

### DIFF
--- a/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/DropwizardDataSourceConfigProvider.java
@@ -24,7 +24,18 @@ import java.util.function.Supplier;
 /**
  * Config provider that determines the configuration for a Dropwizard data source object.
  * <p>
- * Default resolution lookup keys can be found in the constants for this class
+ * Default resolution lookup keys are as follows:
+ * <ul>
+ *     <li>System Property: kiwi.datasource.driverClass, kiwi.datasource.url, kiwi.datasource.user,
+ *     kiwi.datasource.password, kiwi.datasource.maxSize, kiwi.datasource.minSize,
+ *     kiwi.datasource.initialSize, kiwi.datasource.ormProperties</li>
+ *     <li>Environment Variable: KIWI_DATASOURCE_DRIVER_CLASS, KIWI_DATASOURCE_URL, KIWI_DATASOURCE_USER,
+ *     KIWI_DATASOURCE_PASSWORD, KIWI_DATASOURCE_MAX_SIZE, KIWI_DATASOURCE_MIN_SIZE,
+ *     KIWI_DATASOURCE_INITIAL_SIZE, KIWI_DATASOURCE_ORM_PROPERTIES</li>
+ *     <li>External Config File: datasource.driverClass, datasource.url, datasource.user,
+ *     datasource.password, datasource.maxSize, datasource.minSize,
+ *     datasource.initialSize, datasource.ormProperties</li>
+ * </ul>
  * @see SinglePropertyResolver for resolution order
  */
 public class DropwizardDataSourceConfigProvider implements ConfigProvider {

--- a/src/main/java/org/kiwiproject/config/provider/TlsConfigProvider.java
+++ b/src/main/java/org/kiwiproject/config/provider/TlsConfigProvider.java
@@ -23,8 +23,21 @@ import java.util.function.Supplier;
 /**
  * Config provider that provides a {@link TlsContextConfiguration}.
  * <p>
- * Default resolution lookup keys can be found in the constants for this class
- *
+ * Default resolution lookup keys are as follows:
+ * <ul>
+ *     <li>System Property: kiwi.tls.keyStorePath, kiwi.tls.keyStorePassword, kiwi.tls.keyStoreType,
+ *     kiwi.tls.trustStorePath, kiwi.tls.trustStorePassword, kiwi.tls.trustStoreType,
+ *     kiwi.tls.verifyHostname, kiwi.tls.disableSniHostCheck, kiwi.tls.protocol,
+ *     kiwi.tls.supportedProtocols, kiwi.tls.supportedCiphers</li>
+ *     <li>Environment Variable: KIWI_TLS_KEYSTORE_PATH, KIWI_TLS_KEYSTORE_PASSWORD, KIWI_TLS_KEYSTORE_TYPE,
+ *     KIWI_TLS_TRUSTSTORE_PATH, KIWI_TLS_TRUSTSTORE_PASSWORD, KIWI_TLS_TRUSTSTORE_TYPE,
+ *     KIWI_TLS_VERIFY_HOSTNAME, KIWI_TLS_DISABLE_SNI_HOST_CHECK, KIWI_TLS_PROTOCOL,
+ *     KIWI_TLS_SUPPORTED_PROTOCOLS, KIWI_TLS_SUPPORTED_CIPHERS</li>
+ *     <li>External Config File: tls.keyStorePath, tls.keyStorePassword, tls.keyStoreType,
+ *     tls.trustStorePath, tls.trustStorePassword, tls.trustStoreType,
+ *     tls.verifyHostname, tls.disableSniHostCheck, tls.protocol,
+ *     tls.supportedProtocols, tls.supportedCiphers</li>
+ * </ul>
  * @see SinglePropertyResolver Resolution order defined in SinglePropertyResolver
  */
 public class TlsConfigProvider implements ConfigProvider {


### PR DESCRIPTION
These two classes had placeholder Javadoc saying "Default resolution lookup keys can be found in the constants for this class" rather than explicitly listing the system property names, environment variable names, and external config file keys. Updated to match the style used across the rest of the provider classes.

Closes #379